### PR TITLE
Correct soft pedal note assignment, make red Welte default again

### DIFF
--- a/src/Expressionizer.cpp
+++ b/src/Expressionizer.cpp
@@ -30,8 +30,8 @@ using namespace smf;
 //
 
 Expressionizer::Expressionizer(void) {
-    //setupRedWelte();  // default setup is for Red Welte rolls.
-    setupGreenWelte();
+    setupRedWelte();  // default setup is for Red Welte rolls.
+    //setupGreenWelte();
 }
 
 
@@ -54,8 +54,8 @@ void Expressionizer::setupRedWelte(void) {
     // expression keys for Red Welte rolls:
     PedalOnKey     = 106;
     PedalOffKey    = 107;
-    SoftOnKey      = 22;
-    SoftOffKey     = 23;
+    SoftOnKey      = 21;
+    SoftOffKey     = 20;
     roll_type      = "red";
     slow_decay_rate  = 2380;  //2380
     fastC_decay_rate = 300; // test roll shows around 170ms-200ms from min to MF hook


### PR DESCRIPTION
The soft pedal on/off MIDI key assignments for red Welte rolls were set to incorrect values (22 and 23, rather than 21 and 20) during the refactor of `Expressionizer.cpp` in commit https://github.com/pianoroll/midi2exp/commit/1b5fb6a2ccc78276047b0154c7866716cd43ba2c.

This PR corrects those settings, and reverts to red Welte being the default roll type for expression emulation (not that this matters very much).